### PR TITLE
SCC Review comments on Day03

### DIFF
--- a/year18/src/day03.rs
+++ b/year18/src/day03.rs
@@ -27,6 +27,8 @@ impl FabricClaim {
         Self {
             id,
             top_left: SquareInch { x, y },
+            // SCC There's a subtlty here: the top_right and bottom_left squares aren't included in the fabric claim, while top_left is.  This works out with the all_sq_inches() implementation because of how for iterators are bounded but leads to your overlap() function being wrong.
+            // SCC We're also storing the same state multiple times.  I'd recommend making top_right and bottom_left (or slight variants on them) functions of the FabricClaim rather than saved values, if you even need to use them at all.
             top_right: SquareInch { x: x+width, y },
             bottom_left: SquareInch { x, y: y+height },
             width,
@@ -35,6 +37,7 @@ impl FabricClaim {
     }
 
     fn all_sq_inches(&self) -> Vec<SquareInch> {
+        // SCC ::with_capacity() is a neat touch that I fail to make use of, nice!
         let mut sq_inches = Vec::with_capacity(
             self.height as usize * self.width as usize
         );
@@ -48,6 +51,7 @@ impl FabricClaim {
 
     fn from_input_line(input_line: &str) -> FabricClaim {
         let re = Regex::new(r"#(\d+) @ (\d+),(\d+): (\d+)x(\d+)").unwrap();
+        // SCC This seems like a solid way of getting the values from the string (and probably better than my method of using repeated .split()s!)  I've heard of people using Nom but I haven't looked into that, but if you're finding regex matching slow that might be something to look into.
         re.captures(input_line).map(|cap| {
             let id = FromStr::from_str(&cap[1]).unwrap();
             let x = FromStr::from_str(&cap[2]).unwrap();
@@ -56,9 +60,12 @@ impl FabricClaim {
             let height = FromStr::from_str(&cap[5]).unwrap();
             FabricClaim::new(id, x, y, width, height)
         }).unwrap()
+        // SCC Personal preference: I like to use .expect("Error message") in my AoC code where I know it will work because of the input/problem statement but it's not enforced by the code, and only use .unwrap() if something about the code itself guarantees the unwrap is safe. I'd recommend it partly for debugging purposes and partly to make sure you're thinking "why am I sure this is safe" whenever you do unwrap something.
+        // In this case, it's dependent on the unput matching your expectations, so I'd go with "expect".  In the first line of this function, it's guaranteed to work so long as it's worked once and Regex::new() doesn't change under your feet, so unwrap is probably fine.
     }
 
     fn overlaps(&self, other: &FabricClaim) -> bool {
+        // SCC This looks bugged - it'll return false positives when one claim starts immediately after the end of the other one (if self.top_left.x == other.top_right.x, the two pieces don't overlap, since top_right isn't in the claim).
         if self.top_left.x > other.top_right.x ||
         self.top_right.x < other.top_left.x ||
         self.top_left.y > other.bottom_left.y ||
@@ -73,6 +80,9 @@ impl FabricClaim {
 pub fn day03(input_lines: &[Vec<String>]) -> (String, String) {
     let now = Instant::now();
 
+    // SCC Why are you storing this as a HashSet?  There are two concerns with doing this:
+    // 1. (Hypothetical) You'll drop duplicate claims, but the puzzle doesn't say anything about that: if you had two identical claims, you should consider them to fully overlap and you'd want to know you had two.  This doesn't apply here because each claim has a unique ID, but it's worth bearing in mind.
+    // 2. (Actual) HashSets are more expensive to add and remove entries from than Vectors, but give you the benefit of being easier to find if a given element is in it or not (and guaranteeing no duplicate entries).  You're not using those beneifts here, so I think you'd be strictly better off with a Vector.
     let fabric_claims: HashSet<FabricClaim> = input_lines[0]
         .iter()
         .fold(HashSet::new(), |mut map, line| {
@@ -86,6 +96,7 @@ pub fn day03(input_lines: &[Vec<String>]) -> (String, String) {
 
     let (_, contested_inches) = fabric_claims
         .iter()
+    // SCC This might be personal preference, but I think using a .fold() to insert values into mutable HashSets feels a bit awkward.  .fold() is great when you're building up something that's naturally an accumulator but for this I'd just declare the maps you're building up front (as mut) and then do a `for claim in claims` loop.
         .fold(
         (HashSet::<SquareInch>::new(), HashSet::<SquareInch>::new()),
             |(mut claimed, mut contested), claim| {
@@ -99,6 +110,8 @@ pub fn day03(input_lines: &[Vec<String>]) -> (String, String) {
         }
     );
 
+    // SCC This could be more efficient by starting from the all_claim_ids and calling .remove() during the loop, rather than building a second set and calling .difference().
+    // SCC Additionally, if you were keeping this code like this, I'd recommend moving this line down to just before calculation answer2, since we don't use it until then.
     let all_claim_ids: HashSet<i32> = HashSet::from_iter(1..fabric_claims.len() as i32 + 1);
     let mut contested_claim_ids = HashSet::<i32>::new();
     for combination in fabric_claims.iter().combinations(2) {
@@ -112,6 +125,7 @@ pub fn day03(input_lines: &[Vec<String>]) -> (String, String) {
 
     let answer1 = contested_inches.len();
     let answer2: Vec<&i32> = all_claim_ids.difference(&contested_claim_ids).collect();
+    // SCC It'd be worth asserting that answer2.len() == 1 here, since the puzzle has claimed this and if that doesn't hold, you've got a bug - which you might catch before entering a wrong answer.
     (format!("{}", answer1), format!("{:?}", answer2[0]))
 }
 
@@ -121,6 +135,7 @@ mod tests {
     use crate::utils::load_input;
 
     #[test]
+    // SCC Ah, you haven't filed in the UT framework I provided!  This would have caught the overlap() bug above if you'd used the example 3 lines from the puzzle page :)
     fn check_day03_case01() {
         full_test(
 "", // INPUT STRING


### PR DESCRIPTION
I've added review comments in-line. Generally it looks good but I did find one bug :)

The in-line comments don't address the two core questions you asked, which were:

> - I know regex is slow, is there an alternative that's just as good but faster? Splitting the string?
> - Why does my code still take another couple of seconds after parsing the input?

Answering these:
- I don't know if there's a better approach than regex. I've gone with splitting the strig but that's just because it's easier than learning regex!  I have no idea how performance speeds match up.  I've mentioned one alternative in-line (Nom) that I've heard of which might be good, but I haven't tried it either.
- The reason it's slow is because there's a lot of work being done!  Assuming your data set is similar to mine, there are 1K claims, each of which you're creating a several-hundred large hash-set for, and then you're inserting each of those several hundred-thousand elements into one or two HashSets (and that's just part 1!)  That said...I don't know if there's a faster way to solve it.

Two alternative solutions are:

- attempt to reduce the work by considering rectangles instead of unit squares.  For example, if you have the two claims in 1,3; 4x4 and 3,1: 4x4 you can ignore the co-ordinates 0, 2 and 4: your interesting values on both axes are just 1, 3 and 5 and you work out that you have a shared claim on the 3,3 -> 5,5 square, which you can then at the end calculate to be 4 squares large.  If this doesn't make sense, have a look at my solution - this is what I'm doing.  That said, I do all the calculation of the interesting values up front and my code takes nearly 10 times as long as yours overall!  So I think if this is going to pay off, you'd have to do the 'working out of interesting bound values' dynamically rather than looping all the claims yet again.

- Consider looping over the plain square inches instead of the claim objects.  Rather than constructing claims full of HashSets of co-ords, simply loop over (x,y) pairs and count how many claims each one is in by comparing to the corners you've parsed.  This might still be slow (the co-ords are about 1000x1000 for 1M loop entries, each of which we'd then be checking against up to 1000 claims) but each check is small and we don't need to spend time on HashSets at all that way, so this might work out faster in the long run.

Hopefully that all makes sense; let me know if you'd like to discuss any of it!